### PR TITLE
Adjustments to allow respawning

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -123,7 +123,7 @@
   - type: GameRule
   - type: RespawnDeadRule
   - type: RespawnTracker
-    respawnDelay: 180
+    respawnDelay: 600
 
 # event schedulers
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -115,6 +115,16 @@
   components:
   - type: ZombieRule
 
+- type: entity
+  id: RespawnPrim14
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: GameRule
+  - type: RespawnDeadRule
+  - type: RespawnTracker
+    respawnDelay: 180
+
 # event schedulers
 - type: entity
   id: BasicStationEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -171,5 +171,8 @@
   alias:
   - survival-prim14
   name: survival-title
-  showInVote: false # secret
+  showInVote: false
   description: survival-description
+  supportedMaps: Prim14MapPool
+  rules:
+    - RespawnPrim14


### PR DESCRIPTION
Basically, things were hardcoded so that you had to also have Deathmatch and Points for Respawning mid-round to work. This change makes it possible to just have respawning, without needing deathmath or points.